### PR TITLE
Adds code of conduct page

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -9,6 +9,7 @@ const Router = EmberRouter.extend({
 Router.map(function() {
   this.route('/');
   this.route('program');
+  this.route('code-of-conduct');
 });
 
 export default Router;

--- a/app/routes/code-of-conduct.js
+++ b/app/routes/code-of-conduct.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/app/styles/templates/_main.scss
+++ b/app/styles/templates/_main.scss
@@ -1,2 +1,3 @@
+@import 'code-of-conduct';
 @import 'index';
 @import 'program';

--- a/app/styles/templates/code-of-conduct.scss
+++ b/app/styles/templates/code-of-conduct.scss
@@ -1,0 +1,14 @@
+.code-of-conduct {
+  &-message {
+    border: 1px solid #666;
+    background: white;
+    margin: 2rem auto;
+    padding: 1rem 3rem;
+    border-radius: 2px;
+    font-size:1.5rem;
+    &-back{
+      text-align: center;
+      margin: 2rem 0;
+    }
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -4,14 +4,13 @@
 </header>
 <main>
   {{outlet}}
-  {{!--{{buy-tickets ticketSalesDisabled=true}}--}}
-  {{sponsors-list premierSponsors=model.premierSponsors supportingSponsors=model.supportingSponsors}}
 </main>
 <footer>
   <nav>
     <!--todo: footer nav contents-->
+    {{link-to 'Home' 'index'}}
     <a href="http://emberwomen.com/">Women: Get Involved</a>
-    <a href="http://emberconf.com/code-of-conduct.html">Code of Conduct</a>
+    {{link-to 'Code of Conduct' 'code-of-conduct'}}
     <a href="mailto:chicago@embercamp.com">Get in Touch</a>
     <a href="http://tilde.io/">© Tilde Inc. 2018</a>
   </nav>

--- a/app/templates/code-of-conduct.hbs
+++ b/app/templates/code-of-conduct.hbs
@@ -1,0 +1,41 @@
+<div class="code-of-conduct">
+  <section>
+    <h2 class="ribbon ribbon--left ribbon--centered">Code of Conduct</h2>
+    <div class="code-of-conduct-message">
+      <h3 class="text-center">No Jerks Allowed!</h3>
+      <p>We’re committed to being an inclusive, welcoming conference for everyone. Anyone asked to stop any harassing
+        behavior is expected to comply immediately. We reserve the right to warn or expel offenders from the conference
+        with no refund, and to bar them from future participation, both speaking and attendance.</p>
+
+      <p>If you are being harassed, see someone else being harassed, or have any other concerns while at the event,
+        please
+        tell a staff member (identifiable by their shirts) immediately. For less urgent issues, you are also welcome to
+        <a href="mailto:chicago@embercamp.com">email the organizers</a> (directly, or you can reply to any of the email
+        reminders and announcements we've sent), though we do encourage reporting any issues <em>promptly</em>.</p>
+
+      <p>Please read through the <a href="http://emberjs.com/guidelines/" target="_blank">Ember.js Project Community
+        Guidelines</a> for a more detailed overview of the intent and goals of the Ember community at large. We stand by
+        the principles of the community CoC and consider them part of our CoC as well.</p>
+
+      <p>For purposes of clarity, harassment includes, but is not strictly limited to: offensive verbal comments related
+        to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size,
+        race, ethnicity, religion, sexual images in public spaces, deliberate intimidation, stalking, following,
+        harassing
+        photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and
+        unwelcome sexual attention.</p>
+
+      <p>
+        <small class="adaptation-notice">
+          This policy was adapted from a sample by
+          <a href="http://geekfeminism.org" target="_blank">Geek Feminism</a> with changes from
+          <a href="http://confcodeofconduct.com/" target="_blank">ConfCodeofConduct.com</a> and
+          <a target="_blank" href="https://emberconf.com/code-of-conduct.html">EmberConf</a>.
+        </small>
+      </p>
+
+      <p class="code-of-conduct-message-back">
+        {{link-to 'Back to Conference Details' 'index'}}
+      </p>
+    </div>
+  </section>
+</div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -36,3 +36,6 @@
     {{link-to 'See full program' 'program' classNames='program-link'}}
   --}}
 </section>
+
+{{!--{{buy-tickets ticketSalesDisabled=true}}--}}
+{{sponsors-list premierSponsors=model.premierSponsors supportingSponsors=model.supportingSponsors}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,6 +8,7 @@ module.exports = function(defaults) {
     prember: {
       urls: [
         '/',
+        'code-of-conduct',
         '/program'
       ]
     },

--- a/tests/unit/routes/code-of-conduct-test.js
+++ b/tests/unit/routes/code-of-conduct-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | code-of-conduct', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:code-of-conduct');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
- Adds code of conduct page adapted from emberconf code of conduct
- "email the organizers" is set to `mailto:chicago@embercamp.com`