### PR TITLE
link header image back to root

### DIFF
--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -20,7 +20,7 @@ header {
   padding: 1rem;
 }
 
-header > img, header .logo > img {
+header img, header .logo > img {
   display: block;
   height: auto;
   margin: 0 auto;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,6 @@
 <header role="banner">
   <h1 class="sr-only">Ember Camp Chicago 2018</h1>
-  <a href="/">
+  <a href="/" aria-label="Home">
     <img src="/assets/images/embercamp-chicago-white.png" width="180" height="72" alt="" role="presentation"/>
   </a>
 </header>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,8 @@
 <header role="banner">
   <h1 class="sr-only">Ember Camp Chicago 2018</h1>
-  <img src="/assets/images/embercamp-chicago-white.png" width="180" height="72" alt="" role="presentation"/>
+  <a href="/">
+    <img src="/assets/images/embercamp-chicago-white.png" width="180" height="72" alt="" role="presentation"/>
+  </a>
 </header>
 <main role="main">
   {{outlet}}


### PR DESCRIPTION
When viewing the /speakers page, you have no easy way to get back to the root. A common convention is to link the site logo back to the root. This PR implements that pattern.