### PR TITLE
Set up a _redirects file for netlify routing

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,4 @@
+# netlify redirects for server-side routing to client-side routing
+
+# redirect all server-handled routes to our primary entry point
+/*    /   200


### PR DESCRIPTION
Right now, going to http://embercamp.com/program directly will fail, but going to http://embercamp.com and clicking on a link to http://embercamp.com/program will work. This is because the client-side routing is handled by ember, but the initial server-side routing sees `/program` and doesn't know what to server.

Netlify supports server-side redirects to handle this. They suggest something like the change in this PR for single-page apps that rely on client-side routing. https://www.netliy.com/docs/redirects/