### PR TITLE
add netlify redirects for server-side redirects

### DIFF
--- a/.netlifyredirects
+++ b/.netlifyredirects
@@ -1,0 +1,2 @@
+# redirect all server-handled routes to our primary client-side entry point
+/*    /    200

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-netlify": "^0.0.1",
     "ember-cli-qunit": "^4.1.1",
     "ember-cli-sass": "^7.1.7",
     "ember-cli-shims": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2182,6 +2182,12 @@ ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
 
+ember-cli-netlify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-netlify/-/ember-cli-netlify-0.0.1.tgz#a045dfee11e4760f792c0d7b17881e2bf2692e86"
+  dependencies:
+    fs-extra "^5.0.0"
+
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz#0b14f7bcbc599aa117b5fddc81e4fd03c4bad5b7"


### PR DESCRIPTION
Right now, going to http://embercamp.com/program directly will fail, but going to http://embercamp.com and clicking on a link to http://embercamp.com/program will work. This is because the client-side routing is handled by ember, but the initial server-side routing sees /program and doesn't know what to server.

Netlify supports server-side redirects to handle this. They suggest something like the change in this PR for single-page apps that rely on client-side routing. https://www.netliy.com/docs/redirects/

---

Tested at the branch deploy: https://deploy-preview-68--embercamp-chicago.netlify.com/program