### PR TITLE
update date for 2019

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -26,7 +26,7 @@ $gray-dark: #888c8d;
   text-align: center;
 }
 .lead {
-  margin-bottom: 1em;
+  padding: 0;
   font-size: 1em;
   font-weight: 300;
   line-height: 1.4;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,6 +1,6 @@
-{{!-- <section class="lead">
-  <h2 class="text-center">EmberCamp Chicago 2019!</h2>
-</section> --}}
+<section class="lead">
+  <h2 class="text-center">EmberCamp Chicago<br>September 16th, 2019</h2>
+</section>
 
 <section>
   <h2 class="ribbon ribbon--left ribbon--flipped ribbon--centered">Announcement Signup</h2>
@@ -10,7 +10,7 @@
 
 <section>
   <h2 class="ribbon ribbon--right ribbon--flipped ribbon--centered">Details</h2>
-  <p>Join us on August 23rd, 2019 for the second annual EmberCamp Chicago, where we’ll be hosting 150+ of the world’s top Ember
+  <p>Join us on September 16th, 2019 for the second annual EmberCamp Chicago, where we’ll be hosting 150+ of the world’s top Ember
     developers for a full day of Ember talks.
   </p>
   <p>Whether you want to come enjoy the breathtaking views, make new Ember friends, or get the scoop


### PR DESCRIPTION
It's not the best looking. I just used the class that was there before. Should we change this?

[Deploy Preview](https://deploy-preview-72--embercamp-chicago.netlify.com/)