### PR TITLE
adding speaker talk abstracts

### DIFF
--- a/app/constants/speakers.js
+++ b/app/constants/speakers.js
@@ -3,20 +3,22 @@ export const SPEAKERS = [
     name: 'Edward Faulkner',
     twitterHandle: 'eaf4',
     avatar: '/assets/images/speakers/ed-faulkner.jpeg',
-    bio: 'Edward Faulkner is a member of the Ember Framework core team. His open source code is running on mainstream gaming consoles, major social media sites, and hordes of enterprise applications. His consultancy, Polynomial LLC, leads ambitious software projects for a diverse group of businesses and nonprofits, and he is a lead developer for the Cardstack Project. https://cardstack.com ',
+    bio: 'Ed is a member of the Ember Framework core team. His open source code is running on mainstream gaming consoles, major social media sites, and hordes of enterprise applications. His consultancy, Polynomial LLC, leads ambitious software projects for a diverse group of businesses and nonprofits, and he is a lead developer for the Cardstack Project. https://cardstack.com ',
     label: '',
     type: 'speaker',
     talkTitle: 'Compiling Ember',
+    talkAbstract: 'Compilers have a reputation for being esoteric and intimidating. But they don\'t need to be! A compiler is just a program that writes programs. This talk will be a practical tour through the Embroider build system that also teaches compiler concepts along the way. With the power of multi-pass compilation, Embroider can take a long-lived, conventional Ember app and give it lazy loading, code splitting, and tree shaking. All without modifying the app\'s own code.',
     id: 1
   },  
   {
     name: 'Marie Chatfield',
     twitterHandle: 'mariechatfield',
     avatar: '/assets/images/speakers/marie-chatfield.jpg',
-    bio: 'Marie Chatfield writes code and poetry, sometimes at the same time. As a front-end engineering enthusiast, she’s currently helping the fine folks at Pingboard build the world’s best org chart software. She is passionate about creating inclusive experiences and understanding foundational web technologies at a deeper level. Talk to her about rock climbing or Texas!',
+    bio: 'Marie writes code and poetry, sometimes at the same time. As a front-end engineering enthusiast, she’s currently helping the fine folks at Pingboard build the world’s best org chart software. She is passionate about creating inclusive experiences and understanding foundational web technologies at a deeper level. Talk to her about rock climbing or Texas!',
     label: '',
     type: 'speaker',
     talkTitle: 'Don’t Just Put a <div> On It—Use the Power of the Browser!',
+    talkAbstract: 'The humble <div> is a powerful and flexible element. Throw enough CSS and JavaScript on it, and a can be anything. But should it be? “Semantic HTML” is a method of using elements that best match what your content means and does. But how do you write better markup if you don’t know your options? Join the learning journey to fill your semantic HTML toolkit with the coolest elements you never knew existed. Learn specific elements to use in different scenarios and how to wield the full power of the HTML spec. You’ll write less code while making your pages more accessible and mobile-friendly!',
     id: 2
   },
   {
@@ -27,6 +29,7 @@ export const SPEAKERS = [
     label: '',
     type: 'speaker',
     talkTitle: 'Content Choreography: Meaningful Motion in Ember Apps',
+    talkAbstract: 'We naturally invent stories to explain phenomena we can\'t understand. If your app leaves changes "vague," users will make up explanations about how it works. Some developers see animation as a fancy gimmick to slap on at the end of a project. Others want to use it in a helpful way but aren\'t sure how. Both will learn that animation is a meaningful tool and how to use it effectively to reduce user error. In this talk, we\'ll avoid getting in the weeds with addons, JS libraries, or CSS frameworks. Instead we\'ll learn the ways that animation can aid your users and see practical UI examples.',
     id: 3
   },
 
@@ -34,10 +37,11 @@ export const SPEAKERS = [
     name: 'Jessica Jordan',
     twitterHandle: 'jjordan_dev',
     avatar: '/assets/images/speakers/jessica-jordan.jpg',
-    bio: 'Jessica Jordan is a member of the Ember Learning Core team and a software engineer at simplabs. She is an editor at The Ember Times and organizes the Ember Berlin meetup. She is passionate about open-source, CSS, art and comics.',
+    bio: 'Jessica is a member of the Ember Learning Core team and a software engineer at simplabs. She is an editor at The Ember Times and organizes the Ember Berlin meetup. She is passionate about open-source, CSS, art and comics.',
     label: '',
     type: 'speaker',
     talkTitle: 'Steady State with Ember Octane',
+    talkAbstract: '​​Ever wondered where your component state went or where it came from? ​​In this talk you will learn how arguments, decorators and tracked properties make state management of your component built in Ember Octane easier than ever before. In comparison with patterns known from traditional Ember apps, you will learn how to transform your modern components to predictable and future-proof building blocks of your application.',
     id: 4
   },
   {
@@ -48,6 +52,7 @@ export const SPEAKERS = [
     label: '',
     type: 'speaker',
     talkTitle: 'Worker Power!',
+    talkAbstract: 'Web workers bring a new layer of capabilities to web applications. Because workers operate on their own threads, they provide a way to perform processor-intensive tasks without affecting the responsiveness of an application. This talk will explore the different types of workers, including service workers and shared workers, and how to make the most of them in your Ember applications. We\'ll discuss the capabilities available to workers and explore different use cases, including progressive web apps.',
     id: 5
   },
   {
@@ -58,6 +63,7 @@ export const SPEAKERS = [
     label: '',
     type: 'speaker',
     talkTitle: 'Navigating Towards Stronger App Architecture Using Maps',
+    talkAbstract: 'Like the cities they represent, interactive maps are complicated feats of engineering. They are resource-intensive microcosms of state management, requiring special data formats and styling specifications. When the needs of an application go beyond showing points on a map, cartographic applications can quickly grow unwieldy and unsustainable. Throw moving targets, messy data, and squeezed timelines into the mix, and you\'ve got an enormous component that does everything – poorly. This talk discusses the latest mapping technology and approaches to building better components - map-based or otherwise.',
     id: 6
   },
   
@@ -69,6 +75,7 @@ export const SPEAKERS = [
     label: '',
     type: 'speaker',
     talkTitle: 'May I ask a question, LIVE!',
+    talkAbstract: 'As Ms. Frizzle says, "Take chances, make mistakes, get messy!" Join two Ember developers as they livestream Ember Q&A from the Stack Overflow, the Discuss Forums, and the audience. In this activity, Jen and Preston will teach strategies for leveling up the skills necessary for positive interactions and and get answers to your own burning questions!',
     id: 7
   },
   {
@@ -79,6 +86,7 @@ export const SPEAKERS = [
     label: '',
     type: 'speaker',
     talkTitle: 'May I ask a question, LIVE!',
+    talkAbstract: 'As Ms. Frizzle says, "Take chances, make mistakes, get messy!" Join two Ember developers as they livestream Ember Q&A from the Stack Overflow, the Discuss Forums, and the audience. In this activity, Jen and Preston will teach strategies for leveling up the skills necessary for positive interactions and and get answers to your own burning questions!',
     id: 8
   },
   {
@@ -89,6 +97,7 @@ export const SPEAKERS = [
     label: '',
     type: 'speaker',
     talkTitle: 'Modifiers: the Good and the Camp',
+    talkAbstract: 'During the rush up to Ember Conf and the formal release of Ember Octane, Element modifiers seemed to magically appear through a series of blog posts that identified a brand-new base tool for Ember applications. Since they are still so new: When should we use them? How should we use them? When should we not use them? In this talk, we\'ll explore a number of use cases and explore how to model them using modifiers. Some good; some ambiguous; some plain silly.',
     id: 9
   },
   {
@@ -99,6 +108,7 @@ export const SPEAKERS = [
     label: '',
     type: 'speaker',
     talkTitle: 'Mocks, Spies, and Timers - Oh My!',
+    talkAbstract: 'The testing world is full of ways to simulate data and user interaction. Mocks, spies, stubs, and timers all allow you to focus your tests and remove unwanted interference. Maybe you\'ve tried to set them up and been overwhelmed or maybe you\'ve never even heard of them. Core concepts can help developers frame their thoughts about testing and structuring tests. We\'ll explore those core concepts and look at how to leverage existing libraries like Sinon.js, Pretender.js, and even ember-cli-mirage, with examples to make your test suite more stable and reliable.',
     id: 10
   },
   {
@@ -109,6 +119,7 @@ export const SPEAKERS = [
     label: '',
     type: 'speaker',
     talkTitle: 'Build One Get Two --- Guide For When To Leverage Corber',
+    talkAbstract: '',
     id: 11
   },
   
@@ -120,6 +131,7 @@ export const SPEAKERS = [
     label: '',
     type: 'keynote',
     talkTitle: 'Closing Keynote Speaker',
+    talkAbstract: '',
     id: 12
   }, 
 ];

--- a/app/styles/components/speaker-details.scss
+++ b/app/styles/components/speaker-details.scss
@@ -81,3 +81,6 @@
     }
   }
 }
+p.speakers-list-item-bio {
+  padding-top: 0.5em;
+}

--- a/app/templates/speakers.hbs
+++ b/app/templates/speakers.hbs
@@ -7,10 +7,23 @@
           {{{speaker-details speaker=speaker}}}
           <div class="speakers-list-item-info">
             <h3 class="speakers-list-item-title">{{speaker.talkTitle}}</h3>
-            <h4>About {{speaker.name}}:</h4>
-            <p class="speakers-list-item-bio">
-              {{speaker.bio}}
-            </p>
+            {{#if speaker.talkAbstract}}
+            <p>{{speaker.talkAbstract}}</p>
+            <details>
+              <summary>About {{speaker.name}}</summary>
+              <p class="speakers-list-item-bio">
+                {{speaker.bio}}
+              </p>
+            </details>
+            {{else}}
+              <details open>
+                <summary>About {{speaker.name}}</summary>
+                <p class="speakers-list-item-bio">
+                  {{speaker.bio}}
+                </p>
+              </details>
+            {{/if}}
+
           </div>
         </li>
       {{/each}}


### PR DESCRIPTION
If merged, this PR:

- adds talk abstracts and moves speaker bios into a `<detail>` element
- If the speaker doesn't have an abstract yet, the `<detail>` element is opened, so the space appears balanced
- updates bios to use first names, since having the full name in the `<summary>` element and the immediately following paragraph was too repetitive