### PR TITLE
updating ribbon orientation

### DIFF
--- a/app/styles/components/speaker-details.scss
+++ b/app/styles/components/speaker-details.scss
@@ -4,7 +4,7 @@
   flex-wrap: wrap;
   justify-content: center;
   list-style: none outside;
-  margin: 0 auto;
+  margin: 0 auto 1em auto;
   max-width: 90% !important;
   padding: 0;
 }
@@ -12,9 +12,7 @@
 .speaker-list li {
   margin: 1rem;
   text-align: center;
-  width: calc(33% - 2rem);
   @media screen and (max-width: 968px) {
-    width: calc(60% - 2rem);
     padding-bottom: 1.5rem;
     &:not(:last-of-type) {
       border-bottom: 1px solid #d8d8d8;

--- a/app/templates/components/sponsors-list.hbs
+++ b/app/templates/components/sponsors-list.hbs
@@ -9,7 +9,7 @@
   </p>
 
   {{#if platinum.length}}
-  <h3 class="ribbon ribbon--right ribbon--centered ribbon--skinny ribbon--dark">Platinum Sponsor</h3>
+  <h3 class="ribbon ribbon--left ribbon--centered ribbon--skinny ribbon--dark">Platinum Sponsor</h3>
   <ul class="sponsor-list">
     {{#each platinum as |sponsor|}}
       <li>
@@ -20,7 +20,7 @@
   {{/if}}
 
   {{#if gold.length}}
-    <h3 class="ribbon ribbon--left ribbon--centered ribbon--skinny ribbon--dark">Gold Sponsors</h3>
+    <h3 class="ribbon ribbon--right ribbon--centered ribbon--skinny ribbon--dark">Gold Sponsors</h3>
     <ul class="sponsor-list">
       {{#each gold as |sponsor|}}
         <li>
@@ -31,7 +31,7 @@
   {{/if}}
 
   {{#if silver.length}}
-    <h3 class="ribbon ribbon--right ribbon--centered ribbon--skinny ribbon--dark">Silver Sponsors</h3>
+    <h3 class="ribbon ribbon--left ribbon--centered ribbon--skinny ribbon--dark">Silver Sponsors</h3>
     <ul class="sponsor-list">
       {{#each silver as |sponsor|}}
         <li>
@@ -42,7 +42,7 @@
   {{/if}}
 
   {{#if bronze.length}}
-    <h3 class="ribbon ribbon--left ribbon--centered ribbon--skinny ribbon--dark">Bronze Sponsors</h3>
+    <h3 class="ribbon ribbon--right ribbon--centered ribbon--skinny ribbon--dark">Bronze Sponsors</h3>
     <ul class="sponsor-list">
       {{#each bronze as |sponsor|}}
         <li>


### PR DESCRIPTION
This PR updates the ribbon orientation for the sponsor sub section on the homepage, and removes the width for the speaker list elements, so that they use up space more automatically with the flexbox defaults. 